### PR TITLE
added basic app err parsing

### DIFF
--- a/extract_test.go
+++ b/extract_test.go
@@ -7,10 +7,12 @@ import (
 func TestRepoMirrorLogExample(t *testing.T) {
 	in := `172.31.30.229 - - [19/Jun/2015:09:24:24 +0000] "GET /v1/images/f467d023d63178a6686daab33049b7fec024f88e5b64898e9c89dafaaa4e1d8a/ancestry HTTP/1.1" 200 1836 "-" "docker/1.5.0 go/go1.3.3 git-commit/a8a31ef-dirty kernel/3.19.3 os/linux arch/amd64"`
 
-	out, ok := Extract(in)
+	out, ok := extractAccEntry(in)
+
 	if !ok {
 		t.Fatal("failed to extract values")
 	}
+
 	if out.Status != 200 {
 		t.Errorf("expected status %d but got %d\n", 200, out.Status)
 	}
@@ -20,7 +22,7 @@ func TestRepoMirrorLogExample(t *testing.T) {
 func TestMethodeAPIExample(t *testing.T) {
 	in := `127.0.0.1 - - [21/Apr/2015:12:15:34 +0000] "GET /eom-file/all/e09b49d6-e1fa-11e4-bb7f-00144feab7de HTTP/1.1" 200 53706 919 919`
 
-	out, ok := Extract(in)
+	out, ok := extractAccEntry(in)
 	if !ok {
 		t.Fatal("failed to extract values")
 	}
@@ -32,7 +34,7 @@ func TestMethodeAPIExample(t *testing.T) {
 
 func TestCmsNotifierPostExample(t *testing.T) {
 	in := `172.17.42.1 -  -  [24/Jun/2015:11:09:36 +0000] "POST /notify HTTP/1.1" 500 - "-" "curl/7.42.0" 2197`
-	out, ok := Extract(in)
+	out, ok := extractAccEntry(in)
 	t.Logf("out status value %v", out.Status)
 	if !ok {
 		t.Fatal("failed to extract values")
@@ -41,4 +43,15 @@ func TestCmsNotifierPostExample(t *testing.T) {
 		t.Errorf("expected status %d but got %d\n", 500, out.Status)
 	}
 	// TODO:
+}
+
+func TestCmsNotifierKafkaFetchingTopicError(t *testing.T) {
+	in := `ERROR [2015-08-07 09:03:45,581] kafka.utils.Utils$: transaction_id=tid_lYpxZctRHb_kafka_bridge fetching topic metadata for topics [Set(NativeCmsPublicationEvents)] from broker [ArrayBuffer(id:0,host:172.23.219.136,port:9092)] failed|[dw-3910 - POST /notify]! kafka.common.KafkaException: fetching topic metadata for topics [Set(NativeCmsPublicationEvents)] from broker [ArrayBuffer(id:0,host:172.23.219.136,port:9092)] failed|! at kafka.client.ClientUtils$.fetchTopicMetadata(ClientUtils.scala:67) ~[app.jar:0.0.1-SNAPSHOT]|! at kafka.producer.BrokerPartitionInfo.updateInfo(BrokerPartitionInfo.scala:82) ~[app.jar:0.0.1-SNAPSHOT]|! at kafka.producer.async.DefaultEventHandler$$anonfun$handle$2.apply$mcV$sp(DefaultEventHandler.scala:78) ~[app.jar:0.0.1-SNAPSHOT]|! at kafka.utils.Utils$.swallow(Utils.scala:167) [app.jar:0.0.1-SNAPSHOT]|! at kafka.utils.Logging$class.swallowError(Logging.scala:106) [app.jar:0.0.1-SNAPSHOT]|! at kafka.utils.Utils$.swallowError(Utils.scala:46) [app.jar:0.0.1-SNAPSHOT]|! at kafka.producer.async.DefaultEventHandler.handle(DefaultEventHandler.scala:78) [app.jar:0.0.1-SNAPSHOT]|! at kafka.producer.Producer.send(Producer.scala:76) [app.jar:0.0.1-SNAPSHOT]|! at kafka.javaapi.producer.Producer.send(Producer.scala:33) [app.jar:0.0.1-SNAPSHOT]|! at com.ft.cmsnotifier.service.KafkaMessageProducer.produceNotifyEvent(KafkaMessageProducer.java:30) [app.jar:0.0.1-SNAPSHOT]|! at com.ft.cmsnotifier.resources.CmsNotifierResource.produceEventForContent(CmsNotifierResource.java:59) [app.jar:0.0.1-SNAPSHOT]|! at com.ft.cmsnotifier.resources.CmsNotifierResource.importContent(CmsNotifierResource.java:43) [app.jar:0.0.1-SNAPSHOT]|! at sun.reflect.GeneratedMethodAccessor15.invoke(Unknown Source) ~[na:na]|! at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_51]|! at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_51]|! at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60) [app.jar:0.0.1-SNAPSHOT]|! at com.sun.je`
+	out, ok := extractAppEntry(in)
+	if !ok {
+		t.Fatal("failed to extract values")
+	}
+	if out.Level != "ERROR" {
+		t.Errorf("expected level %s, actual level %s", "ERROR", out.Level)
+	}
 }


### PR DESCRIPTION
Broke down into separate methods extracting the access and app logs, because of easier testing (keeping one single generic method would require type assertion in each unit test). Any thoughts, how could we make this more idiomatic and elegant?