### PR TITLE
Avoid infinite logging

### DIFF
--- a/logfilter/logfilter.go
+++ b/logfilter/logfilter.go
@@ -28,6 +28,10 @@ var (
 		"__CURSOR",
 		"__MONOTONIC_TIMESTAMP",
 	}
+
+	blacklistedUnits = map[string]bool{
+		"splunk-forwarder.service": true,
+	}
 )
 
 var environmentTag *string
@@ -46,6 +50,12 @@ func main() {
 				return
 			}
 			panic(err)
+		}
+		unit := m["_SYSTEMD_UNIT"]
+		if unitString, ok := unit.(string); ok {
+			if blacklistedUnits[unitString] {
+				continue
+			}
 		}
 		munge(m)
 		removeBlacklistedProperties(m)


### PR DESCRIPTION
If the http forwarder errors, we rightly log those errors. We must not
also try to send those errors via the same (failing) component that
caused them, because we'll likely see the same failure and this cycle
will continue until disk, bandwitdth, cpu or something else is
exhausted.