### PR TITLE
Blacklisting /health and /gtg entries

### DIFF
--- a/logfilter/logfilter.go
+++ b/logfilter/logfilter.go
@@ -41,6 +41,8 @@ var (
 
 	blacklistedStrings = []string{
 		"transaction_id=SYNTHETIC-REQ",
+		"__health",
+		"__gtg",
 	}
 
 	propertyMapping = map[string]string{


### PR DESCRIPTION
Blacklisting /health and /gtg entries in order to temporary reduce the logging volume (OpsCop initiative).