### PR TITLE
:bug: Fix transaction_id parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 /.project
 coco-logfilter
 *.idea
+
+/vendor/*/
+!/vendor/vendor.json

--- a/logfilter/logfilter.go
+++ b/logfilter/logfilter.go
@@ -132,7 +132,7 @@ func munge(m map[string]interface{}, message string) {
 	}
 }
 
-var trans_regex = regexp.MustCompile(`\btransaction_id=([\S]+)`)
+var trans_regex = regexp.MustCompile(`\btransaction_id=([A-Za-z0-9\-_:]+)`)
 
 func extractTransactionId(message string) string {
 	matches := trans_regex.FindAllStringSubmatch(message, -1)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,57 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "DuEyF75v9xaKXfJsCPRdHNOpGZk=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "+oyIJwPyeof36XCkY8awrNfxaNM=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "ofNmmhhJAxYL1Mh09iq+utdfHIM=",
+			"path": "github.com/stretchr/objx",
+			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+			"revisionTime": "2015-09-28T12:21:52Z"
+		},
+		{
+			"checksumSHA1": "fPjZ9M1PDFi51iQ0aXEjQG+qLqM=",
+			"path": "github.com/stretchr/testify",
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
+		},
+		{
+			"checksumSHA1": "ziYrpyU5zo1q9+n1kaXqkR3kP2s=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "D4bXPof9qSyXm4ZssBn6J5/FX0U=",
+			"path": "github.com/stretchr/testify/http",
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
+		},
+		{
+			"checksumSHA1": "2317NjgW/wn/UHMRGbfYyZkhoKM=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
+		}
+	],
+	"rootPath": "github.com/Financial-Times/coco-logfilter"
+}


### PR DESCRIPTION
Transaction IDs logged as part of the resilient client User-Agent HTTP
header tend to abut a parenthesis and a quote mark directly, but these
non-whitespace characters should not be extracted into the
transaction_id value that is logged. I've amended the pattern to
accommodate uppercase, lowercase, numbers, hyphen, underscore and colon
and rationalised the test cases. As far as I'm aware these are the only
characters that should appear in a transaction id (the colon is a quirk
of the logging in PAM).